### PR TITLE
Compatability with new ggplot2 version

### DIFF
--- a/R/fitbit_utils.R
+++ b/R/fitbit_utils.R
@@ -356,7 +356,7 @@ plot_data_type = function(dat_type_min, type) {
     ggplot2::ylab(type) +
     ggplot2::xlab("Hour & Minutes") +
     ggplot2::ggtitle(glue::glue("{ylab_name} ('{type}')")) +
-    ggplot2::theme(plot.title = ggplot2::element_text(size = "16", hjust = 0.5, face = "bold", colour = "blue"),
+    ggplot2::theme(plot.title = ggplot2::element_text(size = 16, hjust = 0.5, face = "bold", colour = "blue"),
                    strip.background = ggplot2::element_rect(fill = 'blue', colour='black'),
                    strip.text.x = ggplot2::element_text(size = 16, colour = 'orange', face = 'bold'),
                    axis.title.x = ggplot2::element_text(size = 12, face = "bold", colour = "blue"),
@@ -596,7 +596,7 @@ heart_rate_heatmap = function(heart_rate_intraday_data,
     ggplot2::ylab("Level") +
     ggplot2::ggtitle("Heart Rate Level Heatmap") +
     ggplot2::theme(strip.placement = 'outside',
-                   plot.title = ggplot2::element_text(size = "16", hjust = 0.5, face = "bold", colour = "blue"),
+                   plot.title = ggplot2::element_text(size = 16, hjust = 0.5, face = "bold", colour = "blue"),
                    axis.title.x = ggplot2::element_text(size = 12, face = "bold", colour = "blue"),
                    axis.title.y = ggplot2::element_text(size = 12, face = "bold", colour = "blue"),
                    axis.text.x = ggplot2::element_text(size = 12, face = "bold", colour = "black", angle = angle_x_axis, vjust = 1.0, hjust = 1.0),
@@ -714,7 +714,7 @@ heart_rate_variability_sleep_time = function(heart_rate_data,
       ggplot2::labs(color='Heart Rate Variability (during sleep') +
       ggplot2::geom_point(color = 'green', size = 3) +
       ggplot2::geom_text(ggplot2::aes(label = round(hr_var$hr_variability, 3), fontface = 2), color = "maroon", size = 4, vjust = -2) +
-      ggplot2::theme(plot.title = ggplot2::element_text(size = "16", hjust = 0.5, face = "bold", colour = "blue"),
+      ggplot2::theme(plot.title = ggplot2::element_text(size = 16, hjust = 0.5, face = "bold", colour = "blue"),
                      axis.title.x = ggplot2::element_text(size = 12, face = "bold", colour = "blue"),
                      axis.title.y = ggplot2::element_text(size = 12, face = "bold", colour = "blue"),
                      axis.text.x = ggplot2::element_text(size = 12, face = "bold", colour = "black", angle = angle_x_axis, vjust = 1, hjust=1),
@@ -925,7 +925,7 @@ sleep_heatmap = function(level_data,
     ggplot2::ylab("Level") +
     ggplot2::ggtitle("Sleep Level Heatmap (Minutes & Percentage of sleep)") +
     ggplot2::theme(strip.placement = 'outside',
-                   plot.title = ggplot2::element_text(size = "16", hjust = 0.5, face = "bold", colour = "blue"),
+                   plot.title = ggplot2::element_text(size = 16, hjust = 0.5, face = "bold", colour = "blue"),
                    axis.title.x = ggplot2::element_text(size = 12, face = "bold", colour = "blue"),
                    axis.title.y = ggplot2::element_text(size = 12, face = "bold", colour = "blue"),
                    axis.text.x = ggplot2::element_text(size = 12, face = "bold", colour = "black", angle = angle_x_axis, vjust = 1.0, hjust = 1.0),


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We find that your package had declared an element property as text, whereas we expect a numeric value. 
This PR rectifies this problem.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun